### PR TITLE
support config opening report domain url

### DIFF
--- a/gulp/util/paths.js
+++ b/gulp/util/paths.js
@@ -88,6 +88,7 @@ if(fs.existsSync(paths.activeCaptureConfigPath)){
   } : paths.ci;
 }
 
-paths.compareReportURL = 'http://localhost:' + paths.portNumber + '/compare/';
+paths.domainUrl = argv.domainUrl ? (argv.domainUrl + ':') : 'http://localhost:';
+paths.compareReportURL = paths.domainUrl + paths.portNumber + '/compare/';
 
 module.exports = paths;


### PR DESCRIPTION
Sometimes when i install backstopjs in my linux server, we need the report server url as the linux url but not the 'localhost'.

So i added a 'domainUrl' config for specific the server url.
